### PR TITLE
superclass mismatch for class SQLite3Adapter in Rails 4.0.0.beta1

### DIFF
--- a/lib/acts_as_fu/base.rb
+++ b/lib/acts_as_fu/base.rb
@@ -1,4 +1,5 @@
 require 'active_record'
+require 'active_record/connection_adapters/sqlite3_adapter' 
 require 'logger'
 
 RAILS_ROOT = File.join(File.dirname(__FILE__), '..') unless defined?(RAILS_ROOT)


### PR DESCRIPTION
I was migrating my app to Rails 4.0.0.beta1 and some of my tests happened to be failing with:

```
 TypeError:
   superclass mismatch for class SQLite3Adapter
 # blah-blah/acts_as_fu/lib/acts_as_fu/base.rb:17:in `connect!'
```

It looks like the SQLite3Adapter is no longer autoloaded. Adding a require at the top of base.rb seems to fix the issue. 

Hope this is at least a bit useful. :)
